### PR TITLE
OT249-66: Endpoint Actualización Testimonios

### DIFF
--- a/src/main/java/com/alkemy/ong/controller/TestimonialController.java
+++ b/src/main/java/com/alkemy/ong/controller/TestimonialController.java
@@ -7,10 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -19,6 +16,7 @@ import javax.validation.Valid;
 @AllArgsConstructor
 public class TestimonialController {
     private final TestimonialService testimonialService;
+
     @PostMapping("")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<TestimonialDto> createTestimony(@Valid @RequestBody TestimonialDto testimonialDto, BindingResult bindingResult) {
@@ -26,6 +24,12 @@ public class TestimonialController {
         TestimonialDto newTestimonialDto = testimonialService.createTestimony( testimonialDto, bindingResult);
         return new ResponseEntity<>( newTestimonialDto, HttpStatus.CREATED);
     }
+    @PutMapping("/{id}")
+    @PreAuthorize( "hasAuthority('ADMIN')" )
+    public ResponseEntity<TestimonialDto> updateNews(@PathVariable String id, @Valid @RequestBody TestimonialDto testimonialDto, BindingResult bindingResult){
 
+        TestimonialDto updateTestimony = testimonialService.updateTestimony(id, testimonialDto, bindingResult );
+        return ResponseEntity.ok( updateTestimony );
+    }
 
 }

--- a/src/main/java/com/alkemy/ong/exceptions/CustomExceptionController.java
+++ b/src/main/java/com/alkemy/ong/exceptions/CustomExceptionController.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 @RestControllerAdvice
-public class NewsControllerEx extends ResponseEntityExceptionHandler {
+public class CustomExceptionController extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(BindingResultException.class)
     public ResponseEntity<?> handleValidateExceptions(BindingResultException ex) {

--- a/src/main/java/com/alkemy/ong/service/impl/TestimonialServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/TestimonialServiceImpl.java
@@ -2,6 +2,7 @@ package com.alkemy.ong.service.impl;
 
 import com.alkemy.ong.dto.TestimonialDto;
 import com.alkemy.ong.exceptions.BindingResultException;
+import com.alkemy.ong.exceptions.RecordException;
 import com.alkemy.ong.model.Testimonial;
 import com.alkemy.ong.repository.TestimonialRepository;
 import com.alkemy.ong.service.TestimonialService;
@@ -24,9 +25,18 @@ public class TestimonialServiceImpl implements TestimonialService {
     }
 
     @Override
-    public TestimonialDto updateTestimony(String id, TestimonialDto newsDTO, BindingResult bindingResult) {
+    public TestimonialDto updateTestimony(String id, TestimonialDto testimonialDto, BindingResult bindingResult) {
+        if (bindingResult.hasFieldErrors())
+            throw new BindingResultException( bindingResult );
+        Testimonial found = testimonialRepository.findById( id ).orElseThrow( () -> new RecordException.RecordNotFoundException( "Testimonial not found" ) );
 
-        return null;
+        TestimonialDto mappedTestimonialDto = this.modelMapper.map( found, TestimonialDto.class );
+        mappedTestimonialDto.setContent( testimonialDto.getContent() );
+        mappedTestimonialDto.setImage( testimonialDto.getImage() );
+        mappedTestimonialDto.setName( testimonialDto.getName() );
+        Testimonial testimonialToSave = this.modelMapper.map( mappedTestimonialDto, Testimonial.class );
+        Testimonial savedTestimonial = testimonialRepository.save( testimonialToSave );
+        return this.modelMapper.map( savedTestimonial, TestimonialDto.class );
     }
 
     @Override


### PR DESCRIPTION
- [x] `PUT` `/testimonials/:id`
- [x] Deberá validar que la novedad exista en base al `id` enviado por parámetro. 
- [x] En el caso de que no exista, deberá devolver un error, 
- [x] mientras que en caso contrario, deberá actualizarla y 
- [x] devolverla con los datos nuevos.