### PR TITLE
OT249-80: Agregar paginación a Categorías

### DIFF
--- a/src/main/java/com/alkemy/ong/Utils/PageUtils.java
+++ b/src/main/java/com/alkemy/ong/Utils/PageUtils.java
@@ -1,7 +1,6 @@
 package com.alkemy.ong.Utils;
 
 import com.alkemy.ong.dto.PageDto;
-import com.alkemy.ong.model.Category;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -25,21 +24,26 @@ public class PageUtils {
         PageDto.Links links = new PageDto.Links();
         links.setPrefix(prefix);
         if (page.hasNext())
-            links.setNextLink( String.valueOf( page.getPageable().next().getPageNumber() ) );
-        else if (page.getTotalPages() > page.getPageable().getPageNumber())
-            links.setNextLink( String.valueOf( page.getPageable().getPageNumber() ) );
+            links.setNextOrLast( String.valueOf( page.getPageable().next().getPageNumber() ) );
+        else if (page.getTotalPages() > page.getNumber())
+            links.setNextOrLast( String.valueOf( page.getPageable().getPageNumber() ) );
         else if(page.getTotalPages() > 0)
-            links.setNextLink( String.valueOf( page.getTotalPages() - 1 ) );
+            links.setNextOrLast( String.valueOf( page.getTotalPages() - 1 ) );
         else
-            links.setNextLink( String.valueOf( page.getTotalPages() ) );
+            links.setNextOrLast( String.valueOf( page.getTotalPages() ) );
 
 
         if (page.getTotalPages() > page.getPageable().getPageNumber())
-            links.setPrevLink( String.valueOf( page.getPageable().previousOrFirst().getPageNumber() ) );
+            links.setPrevOrFirst( String.valueOf( page.getPageable().previousOrFirst().getPageNumber() ) );
         else
-            links.setPrevLink( String.valueOf( page.getPageable().first().getPageNumber() ) );
+            links.setPrevOrFirst( String.valueOf( page.getPageable().first().getPageNumber() ) );
 
 
         return links;
+    }
+
+    public static <T> PageDto<?> getPageDto(Page<T> pageDto, String prefix) {
+        PageDto.Links pageLinks = PageUtils.createLinks(pageDto, prefix);
+        return new PageDto<>( pageDto.getContent(), pageDto.getPageable(), pageDto.getTotalElements(), pageLinks );
     }
 }

--- a/src/main/java/com/alkemy/ong/Utils/PageUtils.java
+++ b/src/main/java/com/alkemy/ong/Utils/PageUtils.java
@@ -1,5 +1,8 @@
 package com.alkemy.ong.Utils;
 
+import com.alkemy.ong.dto.PageDto;
+import com.alkemy.ong.model.Category;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -17,4 +20,26 @@ public class PageUtils {
         return PageRequest.of( page, 10, by( sort ) );
     }
 
+    public static <T> PageDto.Links createLinks(Page<T> page, String prefix) {
+
+        PageDto.Links links = new PageDto.Links();
+        links.setPrefix(prefix);
+        if (page.hasNext())
+            links.setNextLink( String.valueOf( page.getPageable().next().getPageNumber() ) );
+        else if (page.getTotalPages() > page.getPageable().getPageNumber())
+            links.setNextLink( String.valueOf( page.getPageable().getPageNumber() ) );
+        else if(page.getTotalPages() > 0)
+            links.setNextLink( String.valueOf( page.getTotalPages() - 1 ) );
+        else
+            links.setNextLink( String.valueOf( page.getTotalPages() ) );
+
+
+        if (page.getTotalPages() > page.getPageable().getPageNumber())
+            links.setPrevLink( String.valueOf( page.getPageable().previousOrFirst().getPageNumber() ) );
+        else
+            links.setPrevLink( String.valueOf( page.getPageable().first().getPageNumber() ) );
+
+
+        return links;
+    }
 }

--- a/src/main/java/com/alkemy/ong/Utils/PageUtils.java
+++ b/src/main/java/com/alkemy/ong/Utils/PageUtils.java
@@ -42,7 +42,7 @@ public class PageUtils {
         return links;
     }
 
-    public static <T> PageDto<?> getPageDto(Page<T> pageDto, String prefix) {
+    public static <T> PageDto<T> getPageDto(Page<T> pageDto, String prefix) {
         PageDto.Links pageLinks = PageUtils.createLinks(pageDto, prefix);
         return new PageDto<>( pageDto.getContent(), pageDto.getPageable(), pageDto.getTotalElements(), pageLinks );
     }

--- a/src/main/java/com/alkemy/ong/dto/PageDto.java
+++ b/src/main/java/com/alkemy/ong/dto/PageDto.java
@@ -1,30 +1,38 @@
 package com.alkemy.ong.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
-import java.util.function.Function;
 
 @Setter
 @Getter
 public class PageDto<T> extends PageImpl<T> {
     private Links _links;
 
-    public PageDto(List<T> content, Pageable pageable, long total) {
+    @Override
+    @JsonIgnore
+    public Sort getSort() {
 
-        super( content, pageable, total );
+        return super.getSort();
     }
 
     @Override
-    public <U> Page<U> map(Function<? super T, ? extends U> converter) {
+    @JsonIgnore
+    public Pageable getPageable() {
 
-        return super.map( converter );
+        return super.getPageable();
+    }
+
+    public PageDto(List<T> content, Pageable pageable, long total) {
+
+        super( content, pageable, total );
     }
 
     public PageDto(List<T> content, Pageable pageable, long total, Links _links) {
@@ -37,18 +45,18 @@ public class PageDto<T> extends PageImpl<T> {
     @NoArgsConstructor
     @AllArgsConstructor
     public static final class Links{
-        private String nextLink;
-        private String prevLink;
+        private String nextOrLast;
+        private String prevOrFirst;
         private String prefix;
 
-        public String getNextLink() {
+        public String getNextOrLast() {
 
-            return "/" + prefix + "?page="+ nextLink;
+            return "/" + prefix + "?page="+ nextOrLast;
         }
 
-        public String getPrevLink() {
+        public String getPrevOrFirst() {
 
-            return "/" + prefix + "?page="+ prevLink;
+            return "/" + prefix + "?page="+ prevOrFirst;
         }
 
     }

--- a/src/main/java/com/alkemy/ong/dto/PageDto.java
+++ b/src/main/java/com/alkemy/ong/dto/PageDto.java
@@ -1,0 +1,55 @@
+package com.alkemy.ong.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.function.Function;
+
+@Setter
+@Getter
+public class PageDto<T> extends PageImpl<T> {
+    private Links _links;
+
+    public PageDto(List<T> content, Pageable pageable, long total) {
+
+        super( content, pageable, total );
+    }
+
+    @Override
+    public <U> Page<U> map(Function<? super T, ? extends U> converter) {
+
+        return super.map( converter );
+    }
+
+    public PageDto(List<T> content, Pageable pageable, long total, Links _links) {
+
+        super( content, pageable, total );
+        this._links = _links;
+    }
+
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static final class Links{
+        private String nextLink;
+        private String prevLink;
+        private String prefix;
+
+        public String getNextLink() {
+
+            return "/" + prefix + "?page="+ nextLink;
+        }
+
+        public String getPrevLink() {
+
+            return "/" + prefix + "?page="+ prevLink;
+        }
+
+    }
+}

--- a/src/main/java/com/alkemy/ong/service/CategoryService.java
+++ b/src/main/java/com/alkemy/ong/service/CategoryService.java
@@ -1,12 +1,10 @@
 package com.alkemy.ong.service;
 
 import com.alkemy.ong.dto.CategoryDto;
+import com.alkemy.ong.dto.PageDto;
 import com.alkemy.ong.model.Category;
-import org.springframework.data.domain.Page;
 
 import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 
 public interface CategoryService {
     Category getCategory(String id);
@@ -16,5 +14,5 @@ public interface CategoryService {
     void deleteCategory(String id);
     void updateCategory(CategoryDto category, String id);
 
-    Page<Map<String, String>> getAllCategories(int page, String order);
+    PageDto<?> getAllCategories(int page, String order);
 }

--- a/src/main/java/com/alkemy/ong/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/CategoryServiceImpl.java
@@ -69,7 +69,7 @@ public class CategoryServiceImpl implements CategoryService{
 	}
 
     @Override
-    public PageDto<?> getAllCategories(int page, String order) {
+    public PageDto<Map<String, String>> getAllCategories(int page, String order) {
         Page<Category> category = categoryRepository.findAll( PageUtils.getPageable( page, order ) );
         Page<Map<String, String>> categoryDto = category.map( cat -> Map.of( "name", modelMapper.map( cat, CategoryDto.class ).getName()) );
         return PageUtils.getPageDto(categoryDto, "categories");

--- a/src/main/java/com/alkemy/ong/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/CategoryServiceImpl.java
@@ -69,11 +69,10 @@ public class CategoryServiceImpl implements CategoryService{
 	}
 
     @Override
-    public PageDto<Map<String, String>> getAllCategories(int page, String order) {
+    public PageDto<?> getAllCategories(int page, String order) {
         Page<Category> category = categoryRepository.findAll( PageUtils.getPageable( page, order ) );
-        PageDto.Links pageLinks = PageUtils.createLinks(category, "categories");
         Page<Map<String, String>> categoryDto = category.map( cat -> Map.of( "name", modelMapper.map( cat, CategoryDto.class ).getName()) );
-        return new PageDto<>( categoryDto.getContent(), category.getPageable(), category.getTotalPages(), pageLinks );
+        return PageUtils.getPageDto(categoryDto, "categories");
     }
 
 }

--- a/src/main/java/com/alkemy/ong/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/CategoryServiceImpl.java
@@ -2,6 +2,7 @@ package com.alkemy.ong.service.impl;
 
 import com.alkemy.ong.Utils.PageUtils;
 import com.alkemy.ong.dto.CategoryDto;
+import com.alkemy.ong.dto.PageDto;
 import com.alkemy.ong.model.Category;
 import com.alkemy.ong.repository.CategoryRepository;
 import com.alkemy.ong.service.CategoryService;
@@ -13,7 +14,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -69,8 +69,11 @@ public class CategoryServiceImpl implements CategoryService{
 	}
 
     @Override
-    public Page<Map<String, String>> getAllCategories(int page, String order) {
+    public PageDto<Map<String, String>> getAllCategories(int page, String order) {
         Page<Category> category = categoryRepository.findAll( PageUtils.getPageable( page, order ) );
-        return category.map(cat -> Map.of("name", modelMapper.map( cat, CategoryDto.class).getName()));
+        PageDto.Links pageLinks = PageUtils.createLinks(category, "categories");
+        Page<Map<String, String>> categoryDto = category.map( cat -> Map.of( "name", modelMapper.map( cat, CategoryDto.class ).getName()) );
+        return new PageDto<>( categoryDto.getContent(), category.getPageable(), category.getTotalPages(), pageLinks );
     }
+
 }


### PR DESCRIPTION
- [x] Cuando se realice la petición para listar, los resultados deberán paginarse de a 10. 
- [x] En la respuesta, se deberán mostrar los resultados
- [x] las urls para la página anterior y siguiente (si corresponden). La página actual se obtendrá del parámetro de query `?page`